### PR TITLE
Support nested test suites

### DIFF
--- a/src/TcUnit.TestAdapter/Models/SystemService.cs
+++ b/src/TcUnit.TestAdapter/Models/SystemService.cs
@@ -186,6 +186,7 @@ namespace TcUnit.TestAdapter.Models
 
             if (handle > 0)
             {
+                ctrl.CloseFile(handle);
                 return true;
             }
 

--- a/src/TcUnit.TestAdapter/Models/TmcDataType.cs
+++ b/src/TcUnit.TestAdapter/Models/TmcDataType.cs
@@ -1,10 +1,13 @@
-﻿using System.Xml.Linq;
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
 
 namespace TcUnit.TestAdapter.Models
 {
     public class TmcDataType : TmcItem
     {
         public string ExtendsType { get; set; }
+
+        public List<TmcSubItem> SubItems { get; set; } = new List<TmcSubItem>();
 
         internal TmcDataType(string name, string extendsType = null)
         {
@@ -25,6 +28,14 @@ namespace TcUnit.TestAdapter.Models
             }
 
             var dataType = new TmcDataType(name, extendsTypeName);
+
+            var subItems = element.Elements("SubItem");
+            if (subItems != null) {
+                foreach ( var subItem in subItems )
+                {
+                    dataType.SubItems.Add(TmcSubItem.Parse(subItem));
+                }
+            }
 
             return dataType;
         }

--- a/src/TcUnit.TestAdapter/Models/TmcSubItem.cs
+++ b/src/TcUnit.TestAdapter/Models/TmcSubItem.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+
+namespace TcUnit.TestAdapter.Models
+{
+    public class TmcSubItem : TmcItem
+    {
+        public string Type { get; set; }
+
+        internal TmcSubItem(string name, string type)
+        {
+            Name = name;
+            Type = type;
+        }
+
+        public static TmcSubItem Parse(XElement element)
+        {
+            string name = element.Element("Name").Value;
+            string type = element.Element("Type").Value;
+
+
+            return new TmcSubItem(name, type);
+        }
+    }
+}

--- a/src/TcUnit.TestAdapter/Models/TwinCATXAEProject.cs
+++ b/src/TcUnit.TestAdapter/Models/TwinCATXAEProject.cs
@@ -46,10 +46,10 @@ namespace TcUnit.TestAdapter.Models
             {
                 var platformName = Path.GetFileName(platform);
 
-                if (Common.RTOperatingSystem.AvailableRTPlattforms.Values.Contains(plattformName))
+                if (Common.RTOperatingSystem.AvailableRTPlattforms.Values.Contains(platformName))
                 {
-                    var bootProjectPath = Path.Combine(bootProjectFolder, plattform);
-                    var bootProject = TwinCATBootProject.ParseFromLocalProjectBuildFolder(bootProjectPath);
+                    var bootProjectPath = Path.Combine(bootProjectFolder, platformName);
+                    var bootProject = TwinCATBootProject.Load(bootProjectPath);
                     _bootProjects.Add(bootProject);
                 }
             }

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/FirstPLC.plcproj
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/FirstPLC.plcproj
@@ -31,6 +31,12 @@
     <Compile Include="POUs\FB_TestSuite2.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\FB_TestSuite3.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\FB_TestSuiteGroup.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\MAIN.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuite3.TcPOU
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuite3.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.9">
   <POU Name="FB_TestSuite3" Id="{4d879f8a-fdf2-40c8-8f49-cdcf59bed915}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_TestSuite3 EXTENDS FB_TestSuite
 VAR_INPUT
@@ -10,8 +10,23 @@ VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[TestCase3A();]]></ST>
+      <ST><![CDATA[TestCase3A();
+TestCase3B();]]></ST>
     </Implementation>
+    <Method Name="TestCase3B" Id="{afc8d5ed-327e-49e4-abdb-e20d5d7453f0}">
+      <Declaration><![CDATA[METHOD TestCase3B
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('TestCase3B');
+
+AssertTrue(TRUE, 'Condition is not true');
+AssertTrue(TRUE, 'Condition is not true');
+
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="TestCase3A" Id="{ba8412ed-a485-4e34-a3cb-2c0117f9ef9e}">
       <Declaration><![CDATA[METHOD TestCase3A
 VAR_INPUT

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuite3.TcPOU
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuite3.TcPOU
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_TestSuite3" Id="{4d879f8a-fdf2-40c8-8f49-cdcf59bed915}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_TestSuite3 EXTENDS FB_TestSuite
+VAR_INPUT
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[TestCase3A();]]></ST>
+    </Implementation>
+    <Method Name="TestCase3A" Id="{ba8412ed-a485-4e34-a3cb-2c0117f9ef9e}">
+      <Declaration><![CDATA[METHOD TestCase3A
+VAR_INPUT
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('TestCase3A');
+
+AssertTrue(TRUE, 'Condition is not true');
+AssertTrue(TRUE, 'Condition is not true');
+
+TEST_FINISHED();]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuiteGroup.TcPOU
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuiteGroup.TcPOU
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.9">
   <POU Name="FB_TestSuiteGroup" Id="{0f5f66b5-a14b-4e9c-b940-1dbbd259c922}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_TestSuiteGroup
 VAR
     fbTestSuite3Instance1 : FB_TestSuite3;
+    fbTestSuite3Instance2 : FB_TestSuite3;
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuiteGroup.TcPOU
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/FB_TestSuiteGroup.TcPOU
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+  <POU Name="FB_TestSuiteGroup" Id="{0f5f66b5-a14b-4e9c-b940-1dbbd259c922}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_TestSuiteGroup
+VAR
+    fbTestSuite3Instance1 : FB_TestSuite3;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/PRG_TESTS.TcPOU
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/FirstPLC/POUs/PRG_TESTS.TcPOU
@@ -6,6 +6,7 @@ VAR
     fbTestSuite1Instance1 : FB_TestSuite1;
     fbTestSuite2Instance1 : FB_TestSuite2;
     fbTestSuite2Instance2 : FB_TestSuite2;
+    fbTestSuiteGroup : FB_TestSuiteGroup;
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/_Config/PLC/FirstPLC.xti
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/_Config/PLC/FirstPLC.xti
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53" ClassName="CNestedPlcProjDef">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.20" ClassName="CNestedPlcProjDef">
 	<Project GUID="{EA0D0955-5CCE-458C-A009-A6F77B8A0B99}" Name="FirstPLC" PrjFilePath="..\..\FirstPLC\FirstPLC.plcproj" TmcFilePath="..\..\FirstPLC\FirstPLC.tmc" ReloadTmc="true" AmsPort="851" TargetArchiveSettings="#x0000" FileArchiveSettings="#x0000">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc" TmcHash="{567DD1C9-3BC9-A471-05A4-6EC2E25F477A}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc">
 			<Name>FirstPLC Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Contexts>
 				<Context>
-					<Id>0</Id>
+					<Id NeedCalleeCall="true">0</Id>
 					<Name>PlcTask2</Name>
 					<ManualConfig>
 						<OTCID>#x02010040</OTCID>
@@ -15,7 +15,7 @@
 					<CycleTime>10000000</CycleTime>
 				</Context>
 				<Context>
-					<Id>1</Id>
+					<Id NeedCalleeCall="true">1</Id>
 					<Name>PlcTask</Name>
 					<ManualConfig>
 						<OTCID>#x02010030</OTCID>

--- a/tests/TcUnit.TestAdapter.Tests/PlcTestProject/_Config/PLC/FirstPLC.xti
+++ b/tests/TcUnit.TestAdapter.Tests/PlcTestProject/_Config/PLC/FirstPLC.xti
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53" ClassName="CNestedPlcProjDef">
 	<Project GUID="{EA0D0955-5CCE-458C-A009-A6F77B8A0B99}" Name="FirstPLC" PrjFilePath="..\..\FirstPLC\FirstPLC.plcproj" TmcFilePath="..\..\FirstPLC\FirstPLC.tmc" ReloadTmc="true" AmsPort="851" TargetArchiveSettings="#x0000" FileArchiveSettings="#x0000">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc" TmcHash="{ADD360D6-6E19-8DC5-715C-AA8336E539BF}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc" TmcHash="{567DD1C9-3BC9-A471-05A4-6EC2E25F477A}">
 			<Name>FirstPLC Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Contexts>

--- a/tests/TcUnit.TestAdapter.Tests/SystemServiceTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/SystemServiceTests.cs
@@ -34,19 +34,38 @@ namespace TcUnit.TestAdapter.Models
         [TestMethod]
         public void FileExistsInBootFolderTests()
         {
+            var testFile = CreateTemporaryFile("TestFile.txt");
+
             var systemService = new SystemService(AmsNetId.LocalHost);
 
-            Assert.IsTrue(systemService.FileExistsInBootFolder("CurrentConfig.xml"));
+            Assert.IsTrue(systemService.FileExistsInBootFolder("TestFile.txt"));
+
+            File.Delete(testFile);
         }
 
         [TestMethod]
         public void CleanUpBootFolder()
         {
+            var testFile = CreateTemporaryFile("TestFile.txt");
+
             var systemService = new SystemService(AmsNetId.LocalHost);
             var targetInfo = systemService.GetDeviceInfo();
             systemService.CleanUpBootDirectory(targetInfo.ImageOsName);
 
-            Assert.IsFalse(systemService.FileExistsInBootFolder("CurrentConfig.xml"));
+            Assert.IsFalse(systemService.FileExistsInBootFolder("TestFile.txt"));
+        }
+
+        private string CreateTemporaryFile(string name)
+        {
+            var bootDir = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Beckhoff\TwinCAT3\3.1", "BootDir", null);
+
+            if (bootDir == null)
+                Assert.Fail("BootDir not found in registry");
+
+            var testFilePath = Path.Combine(bootDir.ToString(), name);
+            File.WriteAllText(testFilePath, "Test");
+
+            return testFilePath;
         }
     }
 }

--- a/tests/TcUnit.TestAdapter.Tests/TestDiscovererTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestDiscovererTests.cs
@@ -31,7 +31,7 @@ namespace TcUnit.TestAdapter.Tests
             testDiscoverer.DiscoverTests(testSources, mockDiscoveryContext, mockLogger, testCaseDiscoverySink);
 
             // Assert
-            Assert.IsTrue(testCaseDiscoverySink.TestCases.Count == 14); 
+            Assert.IsTrue(testCaseDiscoverySink.TestCases.Count == 17); 
         }
     }
 

--- a/tests/TcUnit.TestAdapter.Tests/TestDiscovererTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestDiscovererTests.cs
@@ -31,7 +31,7 @@ namespace TcUnit.TestAdapter.Tests
             testDiscoverer.DiscoverTests(testSources, mockDiscoveryContext, mockLogger, testCaseDiscoverySink);
 
             // Assert
-            Assert.IsTrue(testCaseDiscoverySink.TestCases.Count == 13); 
+            Assert.IsTrue(testCaseDiscoverySink.TestCases.Count == 14); 
         }
     }
 

--- a/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
@@ -42,6 +42,9 @@ namespace TcUnit.TestAdapter.Execution
               "PRG_TESTS.fbTestSuite2Instance2.TestCase2B",
               "PRG_TESTS.fbTestSuite2Instance2.TestCase2C",
               "PRG_TESTS.fbTestSuiteGroup.fbTestSuite3Instance1.TestCase3A",
+              "PRG_TESTS.fbTestSuiteGroup.fbTestSuite3Instance1.TestCase3B",
+              "PRG_TESTS.fbTestSuiteGroup.fbTestSuite3Instance2.TestCase3A",
+              "PRG_TESTS.fbTestSuiteGroup.fbTestSuite3Instance2.TestCase3B"
             };
 
             Assert.IsTrue(testCases.Count() == testCaseNames.Count);
@@ -77,7 +80,7 @@ namespace TcUnit.TestAdapter.Execution
 
             var testRun = testRunner.RunTests(project, tests, settings, logger);
 
-            Assert.IsTrue(testRun.Results.Count() == 14);
+            Assert.IsTrue(testRun.Results.Count() == 17);
         }
     }
 }

--- a/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
@@ -41,6 +41,7 @@ namespace TcUnit.TestAdapter.Execution
               "PRG_TESTS.fbTestSuite2Instance2.TestCase2A",
               "PRG_TESTS.fbTestSuite2Instance2.TestCase2B",
               "PRG_TESTS.fbTestSuite2Instance2.TestCase2C",
+              "PRG_TESTS.fbTestSuiteGroup.fbTestSuite3Instance1.TestCase3A",
             };
 
             Assert.IsTrue(testCases.Count() == testCaseNames.Count);
@@ -76,7 +77,7 @@ namespace TcUnit.TestAdapter.Execution
 
             var testRun = testRunner.RunTests(project, tests, settings, logger);
 
-            Assert.IsTrue(testRun.Results.Count() == 13);
+            Assert.IsTrue(testRun.Results.Count() == 14);
         }
     }
 }

--- a/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
@@ -61,7 +61,7 @@ namespace TcUnit.TestAdapter.Execution
 
 
             var settings = new TestSettings();
-            settings.Target = "127.0.0.1.1.1";  //"192.168.4.1.1.1";
+            settings.Target = "127.0.0.1.1.1";
             settings.CleanUpAfterTestRun = true;
 
             // attempt to clean up the target boot folder


### PR DESCRIPTION
This PR adds the ability to discover tests that are member variables of a function block which is contained in another function block, e.g. `PRG_TESTS.fbTestSuiteGroup.fbTestSuite3Instance1.TestCase3A`. 

Where fbTestSuiteGroup is an instance of FB_TestSuiteGroup containing some test suites.
```
FUNCTION_BLOCK FB_TestSuiteGroup
VAR
    fbTestSuite3Instance1 : FB_TestSuite3;
END_VAR
```

This also fixes a bug in the main branch which prevented the project from compiling, and fixes an issue with the `FileExists` method in SystemService.cs where it would not close the handle to a file.

Unfortunately, this PR does not handle another edge case where tests are contained within a library and "imported" into the project. This will require further thought since the source files for the imported test suites are not readily available using the current implementation.