### PR TITLE
fix: xunit xml schema validation

### DIFF
--- a/src/TcUnit.TestAdapter/Schemas/XUnitXmlSchema.xsd
+++ b/src/TcUnit.TestAdapter/Schemas/XUnitXmlSchema.xsd
@@ -26,7 +26,7 @@
       <xs:attribute name="disabled" type="xs:string"></xs:attribute>
       <xs:attribute name="tests" type="xs:int" use="required"></xs:attribute>
       <xs:attribute name="failures" type="xs:int" use="required"></xs:attribute>
-      <xs:attribute name="time" type="xs:decimal" use="required"></xs:attribute>    
+      <xs:attribute name="time" type="xs:double" use="required"></xs:attribute>    
     </xs:complexType>
   </xs:element>
   
@@ -72,15 +72,14 @@
           
           <xs:attribute name="name" type="xs:token" use="required"></xs:attribute>
           <xs:attribute name="classname" type="xs:token" use="required"></xs:attribute>
-          <xs:attribute name="time" type="xs:decimal" use="required"></xs:attribute>
+          <xs:attribute name="time" type="xs:double" use="required"></xs:attribute>
           
           <xs:attribute name="status" use="required">
             <xs:simpleType>
               <xs:restriction base="xs:string">
                 <xs:minLength value="1"/>
                 <xs:enumeration value="PASS"/>
-                <xs:enumeration value="SKIPPED"/>
-                <xs:enumeration value="FAILED"/>
+                <xs:enumeration value="FAIL"/>
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
@@ -98,7 +97,7 @@
     <xs:attribute name="tests" type="xs:int" use="required"></xs:attribute>  
     <xs:attribute name="failures" type="xs:int" use="required"></xs:attribute>
     <xs:attribute name="skipped" type="xs:int"></xs:attribute>
-    <xs:attribute name="time" type="xs:decimal" use="required"></xs:attribute> 
+    <xs:attribute name="time" type="xs:double" use="required"></xs:attribute> 
   </xs:complexType>
   
   <xs:simpleType name="pre-string">

--- a/tests/TcUnit.TestAdapter.Tests/XUnitTestResultParserTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/XUnitTestResultParserTests.cs
@@ -72,7 +72,7 @@ namespace TcUnit.TestAdapter.Tests
                 @"<?xml version=""1.0"" encoding=""UTF-8""?>
                   <testsuites disabled="""" failures=""2"" tests=""10"" time=""20"">
                     <testsuite id=""0"" name=""TestSuite_1"" tests=""5"" failures=""1"" time=""10"">
-                        <testcase name=""TestCase_1"" classname=""TestSuite_1"" time=""6"" status=""FAILED"">
+                        <testcase name=""TestCase_1"" classname=""TestSuite_1"" time=""6"" status=""FAIL"">
                             <failure message=""My assert message!"" type=""BOOL"" />
                         </testcase>
                         <testcase name=""TestCase_2"" classname=""TestSuite_1"" time=""1"" status=""PASS""></testcase>
@@ -81,7 +81,7 @@ namespace TcUnit.TestAdapter.Tests
                         <testcase name=""TestCase_5"" classname=""TestSuite_1"" time=""1"" status=""PASS""></testcase>
                     </testsuite>
                     <testsuite id=""1"" name=""TestSuite_2"" tests=""5"" failures=""1"" time=""10"">
-                        <testcase name=""TestCase_1"" classname=""TestSuite_2"" time=""6"" status=""FAILED"">
+                        <testcase name=""TestCase_1"" classname=""TestSuite_2"" time=""6"" status=""FAIL"">
                             <failure message=""My assert message!"" type=""BOOL"" />
                         </testcase>
                         <testcase name=""TestCase_2"" classname=""TestSuite_2"" time=""1"" status=""PASS""></testcase>


### PR DESCRIPTION
fixes xUnit XML schema validation on attribute "time" and "status"