### PR TITLE
Changes to support running with usermode runtime, and longer test duration

### DIFF
--- a/src/TcUnit.TestAdapter/Execution/TestRunner.cs
+++ b/src/TcUnit.TestAdapter/Execution/TestRunner.cs
@@ -158,7 +158,7 @@ namespace TcUnit.TestAdapter.Execution
             var target = AmsNetId.Parse(runSettings.Target);
             var cleanUpAfterTestRun = runSettings.CleanUpAfterTestRun;
             var cleanUpBeforeTestRun = true;
-			var testRunTimeout = runSettings.TimeoutSeconds;
+            var testRunTimeout = runSettings.TimeoutSeconds;
 
             var targetRuntime = new TargetRuntime(target);
 

--- a/src/TcUnit.TestAdapter/Execution/TestRunner.cs
+++ b/src/TcUnit.TestAdapter/Execution/TestRunner.cs
@@ -158,6 +158,7 @@ namespace TcUnit.TestAdapter.Execution
             var target = AmsNetId.Parse(runSettings.Target);
             var cleanUpAfterTestRun = runSettings.CleanUpAfterTestRun;
             var cleanUpBeforeTestRun = true;
+			var testRunTimeout = runSettings.TimeoutSeconds;
 
             var targetRuntime = new TargetRuntime(target);
 
@@ -177,7 +178,7 @@ namespace TcUnit.TestAdapter.Execution
 
                 PrepareTargetForTestRun(targetRuntime, project, cleanUpBeforeTestRun);
 
-                PerformTestRunOnTarget(targetRuntime);
+                PerformTestRunOnTarget(targetRuntime, testRunTimeout);
 
                 testResults = CollectTestRunResultsFromTarget(targetRuntime);
             }
@@ -287,11 +288,11 @@ namespace TcUnit.TestAdapter.Execution
             target.CleanUpBootFolder();
         }
 
-        private void PerformTestRunOnTarget(TargetRuntime target)
+        private void PerformTestRunOnTarget(TargetRuntime target, double TimeoutSeconds)
         {
             target.SwitchToRunMode(TimeSpan.FromSeconds(10));
 
-            var isSuccess = RetryUntilSuccessOrTimeout(() => target.IsTestRunFinished(), TimeSpan.FromSeconds(10));
+            var isSuccess = RetryUntilSuccessOrTimeout(() => target.IsTestRunFinished(), TimeSpan.FromSeconds(TimeoutSeconds));
 
             if (!isSuccess)
             {

--- a/src/TcUnit.TestAdapter/Execution/TestRunner.cs
+++ b/src/TcUnit.TestAdapter/Execution/TestRunner.cs
@@ -159,15 +159,6 @@ namespace TcUnit.TestAdapter.Execution
             var cleanUpAfterTestRun = runSettings.CleanUpAfterTestRun;
             var cleanUpBeforeTestRun = true;
 
-            if(AmsNetId.LocalHost != target && AmsNetId.Local != target)
-            {
-                var adsRemoteRoutes = TwinCATEnvironment.GetRemoteRoutes();
-                var targetRoute = adsRemoteRoutes.Where(r => r.NetId.Equals(target));
-
-                if (!targetRoute.Any())
-                    throw new Exception("No ADS route to target found.");
-            }
-
             var targetRuntime = new TargetRuntime(target);
 
             if (!targetRuntime.IsReachable)

--- a/src/TcUnit.TestAdapter/Models/TwinCATXAEProject.cs
+++ b/src/TcUnit.TestAdapter/Models/TwinCATXAEProject.cs
@@ -67,6 +67,11 @@ namespace TcUnit.TestAdapter.Models
 
                 RealtimeSettings = new Tuple<int,int>(sharedCpuCount, isolatedCpuCount);
             }
+			else 
+			{
+				RealtimeSettings = new Tuple<int,int>(1, 0);
+			}
+		
         }
 
         private void ParseBootProjects()

--- a/src/TcUnit.TestAdapter/Models/TwinCATXAEProject.cs
+++ b/src/TcUnit.TestAdapter/Models/TwinCATXAEProject.cs
@@ -67,11 +67,11 @@ namespace TcUnit.TestAdapter.Models
 
                 RealtimeSettings = new Tuple<int,int>(sharedCpuCount, isolatedCpuCount);
             }
-			else 
-			{
-				RealtimeSettings = new Tuple<int,int>(1, 0);
-			}
-		
+            else 
+            {
+                RealtimeSettings = new Tuple<int,int>(1, 0);
+            }
+        
         }
 
         private void ParseBootProjects()

--- a/src/TcUnit.TestAdapter/RunSettings/TestSettings.cs
+++ b/src/TcUnit.TestAdapter/RunSettings/TestSettings.cs
@@ -18,13 +18,13 @@ namespace TcUnit.TestAdapter.RunSettings
         {
             Target = TestAdapter.DefaultTargetRuntime;
             CleanUpAfterTestRun = TestAdapter.DefaultCleanUpAfterTestRun;
-			TimeoutSeconds = TestAdapter.DefaultTimeoutSeconds;
+            TimeoutSeconds = TestAdapter.DefaultTimeoutSeconds;
         }
 
         public string Target { get; set; } 
         public bool CleanUpAfterTestRun { get; set; }
 
-		public double TimeoutSeconds { get; set; } = 10;
+        public double TimeoutSeconds { get; set; } = 10;
 
         public override XmlElement ToXml()
         {

--- a/src/TcUnit.TestAdapter/RunSettings/TestSettings.cs
+++ b/src/TcUnit.TestAdapter/RunSettings/TestSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.Threading;
 using System.Xml;
 using System.Xml.Serialization;
 using TwinCAT.Ads;
@@ -17,10 +18,13 @@ namespace TcUnit.TestAdapter.RunSettings
         {
             Target = TestAdapter.DefaultTargetRuntime;
             CleanUpAfterTestRun = TestAdapter.DefaultCleanUpAfterTestRun;
+			TimeoutSeconds = TestAdapter.DefaultTimeoutSeconds;
         }
 
         public string Target { get; set; } 
         public bool CleanUpAfterTestRun { get; set; }
+
+		public double TimeoutSeconds { get; set; } = 10;
 
         public override XmlElement ToXml()
         {

--- a/src/TcUnit.TestAdapter/Schemas/TestSettingsXmlSchema.xsd
+++ b/src/TcUnit.TestAdapter/Schemas/TestSettingsXmlSchema.xsd
@@ -18,6 +18,14 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+
+        <xs:element name="TimeoutSeconds" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:double">
+
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>    
         
       </xs:sequence>
     </xs:complexType>

--- a/src/TcUnit.TestAdapter/TestAdapter.cs
+++ b/src/TcUnit.TestAdapter/TestAdapter.cs
@@ -22,6 +22,6 @@ namespace TcUnit.TestAdapter
 
         public const string PlcObjClass = "TComPlcObjDef";
 
-		public const double DefaultTimeoutSeconds = 10;
+        public const double DefaultTimeoutSeconds = 10;
     }
 }

--- a/src/TcUnit.TestAdapter/TestAdapter.cs
+++ b/src/TcUnit.TestAdapter/TestAdapter.cs
@@ -21,5 +21,7 @@ namespace TcUnit.TestAdapter
         public const bool DefaultCleanUpAfterTestRun = true;
 
         public const string PlcObjClass = "TComPlcObjDef";
+
+		public const double DefaultTimeoutSeconds = 10;
     }
 }

--- a/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/FirstPLC/FirstPLC.plcproj
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/FirstPLC/FirstPLC.plcproj
@@ -76,7 +76,7 @@
         </Parameter>
         <Parameter ListName="GVL_PARAM_TCUNIT">
           <Key>XUNITFILEPATH</Key>
-          <Value>'C:\TwinCAT\3.1\Runtimes\UmRT_Default\3.1\Boot\tcunit_testresults.xml'</Value>
+          <Value>'%TC_BOOTPRJPATH%tcunit_testresults.xml'</Value>
         </Parameter>
       </Parameters>
     </PlaceholderReference>
@@ -88,7 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="TcUnit">
-      <Resolution>TcUnit, 1.3.0.0 (www.tcunit.org)</Resolution>
+      <Resolution>TcUnit, 1.3.2.0 (www.tcunit.org)</Resolution>
     </PlaceholderResolution>
   </ItemGroup>
   <ProjectExtensions>

--- a/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/FirstPLC/FirstPLC.plcproj
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/FirstPLC/FirstPLC.plcproj
@@ -88,7 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <PlaceholderResolution Include="TcUnit">
-      <Resolution>TcUnit, 1.3.2.0 (www.tcunit.org)</Resolution>
+      <Resolution>TcUnit, 1.3.1.0 (www.tcunit.org)</Resolution>
     </PlaceholderResolution>
   </ItemGroup>
   <ProjectExtensions>

--- a/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/FirstPLC/FirstPLC.plcproj
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/FirstPLC/FirstPLC.plcproj
@@ -76,7 +76,7 @@
         </Parameter>
         <Parameter ListName="GVL_PARAM_TCUNIT">
           <Key>XUNITFILEPATH</Key>
-          <Value>'C:\TwinCAT\3.1\Boot\tcunit_testresults.xml'</Value>
+          <Value>'C:\TwinCAT\3.1\Runtimes\UmRT_Default\3.1\Boot\tcunit_testresults.xml'</Value>
         </Parameter>
       </Parameters>
     </PlaceholderReference>

--- a/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/PlcTestProject.tsproj
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/PlcTestProject.tsproj
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53">
-	<Project ProjectGUID="{B83C6237-4166-47C1-8095-CCC5D82248AA}" TargetNetId="192.168.4.1.1.1" Target64Bit="true" ShowHideConfigurations="#x6">
+	<Project ProjectGUID="{B83C6237-4166-47C1-8095-CCC5D82248AA}" Target64Bit="true" ShowHideConfigurations="#x6">
 		<System>
 			<Tasks>
 				<Task Id="3" Priority="20" CycleTime="100000" AmsPort="350" AdtTasks="true">

--- a/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/PlcTestProject.tsproj
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/PlcTestProject.tsproj
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53">
-	<Project ProjectGUID="{B83C6237-4166-47C1-8095-CCC5D82248AA}" Target64Bit="true" ShowHideConfigurations="#x6">
+	<Project ProjectGUID="{B83C6237-4166-47C1-8095-CCC5D82248AA}" TargetNetId="192.168.4.1.1.1" Target64Bit="true" ShowHideConfigurations="#x6">
 		<System>
-			<Settings MaxCpus="16"/>
 			<Tasks>
 				<Task Id="3" Priority="20" CycleTime="100000" AmsPort="350" AdtTasks="true">
 					<Name>PlcTask</Name>

--- a/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/_Config/PLC/FirstPLC.xti
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/_Config/PLC/FirstPLC.xti
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53" ClassName="CNestedPlcProjDef">
 	<Project GUID="{EA0D0955-5CCE-458C-A009-A6F77B8A0B99}" Name="FirstPLC" PrjFilePath="..\..\FirstPLC\FirstPLC.plcproj" TmcFilePath="..\..\FirstPLC\FirstPLC.tmc" ReloadTmc="true" AmsPort="851" TargetArchiveSettings="#x0000" FileArchiveSettings="#x0000">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc" TmcHash="{0B1CFCED-C40A-F6BE-8603-DCAA4C5013C9}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc" TmcHash="{506D8179-6CA3-5271-44F3-4E0BDDD8DD19}">
 			<Name>FirstPLC Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Contexts>

--- a/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/_Config/PLC/FirstPLC.xti
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/PlcTestProject/_Config/PLC/FirstPLC.xti
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53" ClassName="CNestedPlcProjDef">
 	<Project GUID="{EA0D0955-5CCE-458C-A009-A6F77B8A0B99}" Name="FirstPLC" PrjFilePath="..\..\FirstPLC\FirstPLC.plcproj" TmcFilePath="..\..\FirstPLC\FirstPLC.tmc" ReloadTmc="true" AmsPort="851" TargetArchiveSettings="#x0000" FileArchiveSettings="#x0000">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc" TmcHash="{506D8179-6CA3-5271-44F3-4E0BDDD8DD19}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="FirstPLC\FirstPLC.tmc" TmcHash="{2807A655-B1D2-BA4C-8728-CE0FCD563156}">
 			<Name>FirstPLC Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Contexts>

--- a/tests/TcUnit.TestAdapter.Tests/Assets/TcUnit.runsettings
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/TcUnit.runsettings
@@ -6,7 +6,7 @@
         <TestAdaptersPaths>..\..\src\TcUnit.TestAdapter\bin\Release\netstandard2.0</TestAdaptersPaths>
     </RunConfiguration>
     <TcUnit>
-        <Target>192.168.4.1.1.1</Target> 
+        <Target>127.0.0.1.1.1</Target> 
         <CleanUpAfterTestRun>true</CleanUpAfterTestRun>
     </TcUnit>
 </RunSettings>

--- a/tests/TcUnit.TestAdapter.Tests/Assets/TcUnit.runsettings
+++ b/tests/TcUnit.TestAdapter.Tests/Assets/TcUnit.runsettings
@@ -6,7 +6,7 @@
         <TestAdaptersPaths>..\..\src\TcUnit.TestAdapter\bin\Release\netstandard2.0</TestAdaptersPaths>
     </RunConfiguration>
     <TcUnit>
-        <Target>127.0.0.1.1.1</Target> 
+        <Target>192.168.4.1.1.1</Target> 
         <CleanUpAfterTestRun>true</CleanUpAfterTestRun>
     </TcUnit>
 </RunSettings>

--- a/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
@@ -83,7 +83,7 @@ namespace TcUnit.TestAdapter.Execution
 
 
             var settings = new TestSettings();
-            settings.Target = "127.0.0.1.1.1";
+            settings.Target = "192.168.4.1.1.1";
             settings.CleanUpAfterTestRun = true;
 
             // attempt to clean up the target boot folder

--- a/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
@@ -85,7 +85,7 @@ namespace TcUnit.TestAdapter.Execution
             var settings = new TestSettings();
             settings.Target = "127.0.0.1.1.1";
             settings.CleanUpAfterTestRun = true;
-			settings.TimeoutSeconds = 10;
+            settings.TimeoutSeconds = 10;
 
             // attempt to clean up the target boot folder
             var target = AmsNetId.Parse(settings.Target);

--- a/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
+++ b/tests/TcUnit.TestAdapter.Tests/TestRunnerTests.cs
@@ -83,8 +83,9 @@ namespace TcUnit.TestAdapter.Execution
 
 
             var settings = new TestSettings();
-            settings.Target = "192.168.4.1.1.1";
+            settings.Target = "127.0.0.1.1.1";
             settings.CleanUpAfterTestRun = true;
+			settings.TimeoutSeconds = 10;
 
             // attempt to clean up the target boot folder
             var target = AmsNetId.Parse(settings.Target);


### PR DESCRIPTION
This PR adds support for running the tests of VsTestAdapter using the usermode runtime.

It also adds support for specifying longer test durations.
